### PR TITLE
Remove unnecessary dataset copy on TraveledSpeedsClassifier

### DIFF
--- a/rosie/traveled_speeds_classifier.py
+++ b/rosie/traveled_speeds_classifier.py
@@ -53,13 +53,12 @@ class TraveledSpeedsClassifier(TransformerMixin):
         return _X
 
     def __classify_dataset(self, X):
-        _X = X.copy()
-        _X['expected_distance'] = self._polynomial_fn(_X['expenses'])
-        _X['diff_distance'] = abs(_X['expected_distance'] - _X['distance_traveled'])
-        _X['expenses_threshold_outlier'] = _X['expenses'] > 8
-        threshold = self.__threshold_for_contamination(_X, self.contamination)
-        _X['traveled_speed_outlier'] = _X['diff_distance'] > threshold
-        return _X
+        X['expected_distance'] = self._polynomial_fn(X['expenses'])
+        X['diff_distance'] = abs(X['expected_distance'] - X['distance_traveled'])
+        X['expenses_threshold_outlier'] = X['expenses'] > 8
+        threshold = self.__threshold_for_contamination(X, self.contamination)
+        X['traveled_speed_outlier'] = X['diff_distance'] > threshold
+        return X
 
     def __applicable_rows(self, X):
         return (X['subquota_description'] == 'Congressperson meal') & \


### PR DESCRIPTION
A copy of the whole dataset was being made on __classify_dataset(),
but the same opeartion is performed on its only caller, predict().
This change should save some memory and running time for this
classifier. Not sure if it solves the memory/kill problem, though.

Signed-off-by: Luiz Carlos Cavalcanti <cavalcanti.luiz@gmail.com>