### PR TITLE
Simplifying InvalidCnpjCpfClassifier implementation

### DIFF
--- a/rosie/invalid_cnpj_cpf_classifier.py
+++ b/rosie/invalid_cnpj_cpf_classifier.py
@@ -14,9 +14,7 @@ class InvalidCnpjCpfClassifier(TransformerMixin):
         return self
 
     def predict(self, X):
-        self._X = X.copy()
-        self._X['cnpj_cpf'] = self._X['cnpj_cpf'].astype(np.str)
-        return np.r_[self._X.apply(self.__is_invalid, axis=1)]
+        return np.r_[X.apply(self.__is_invalid, axis=1)]
 
     def __is_invalid(self, row):
-        return (row['document_type'] in [0, 1]) & (not cpfcnpj.validate(row['cnpj_cpf']))
+        return (row['document_type'] in [0, 1]) & (not cpfcnpj.validate(str(row['cnpj_cpf'])))


### PR DESCRIPTION
The InvalidCnpjCpfClassifier was doing unnecessary copy of
the whole dataset and also converting one of the dataframe columns
for no apparent reason. This change should improve running time for
the classifier as well as its memory footprint.

Signed-off-by: Luiz Carlos Cavalcanti <cavalcanti.luiz@gmail.com>