### PR TITLE
WIP: Core obj handling the pipeline

### DIFF
--- a/rosie/chamber_of_deputies/__init__.py
+++ b/rosie/chamber_of_deputies/__init__.py
@@ -1,69 +1,9 @@
-import os.path
-
-import numpy as np
-from sklearn.externals import joblib
-
-from rosie.chamber_of_deputies.dataset import Dataset
-from rosie.chamber_of_deputies.classifiers.election_expenses_classifier import ElectionExpensesClassifier
-from rosie.core.classifiers.invalid_cnpj_cpf_classifier import InvalidCnpjCpfClassifier
-from rosie.chamber_of_deputies.classifiers.meal_price_outlier_classifier import MealPriceOutlierClassifier
-from rosie.chamber_of_deputies.classifiers.monthly_subquota_limit_classifier import MonthlySubquotaLimitClassifier
-from rosie.chamber_of_deputies.classifiers.traveled_speeds_classifier import TraveledSpeedsClassifier
-from rosie.chamber_of_deputies.classifiers.irregular_companies_classifier import IrregularCompaniesClassifier
-
-
-class ChamberOfDeputies:
-    CLASSIFIERS = {
-        MealPriceOutlierClassifier: 'meal_price_outlier',
-        MonthlySubquotaLimitClassifier: 'over_monthly_subquota_limit',
-        TraveledSpeedsClassifier: 'suspicious_traveled_speed_day',
-        InvalidCnpjCpfClassifier: 'invalid_cnpj_cpf',
-        ElectionExpensesClassifier: 'election_expenses',
-        IrregularCompaniesClassifier: 'irregular_companies_classifier'
-    }
-    DATASET_KEYS = ['applicant_id', 'year', 'document_id']
-
-    def __init__(self, dataset, data_path):
-        self.dataset = dataset
-        self.data_path = data_path
-        self.irregularities = self.dataset[self.DATASET_KEYS].copy()
-
-    def run_classifiers(self):
-        for classifier, irregularity in self.CLASSIFIERS.items():
-            model = self.load_trained_model(classifier)
-            self.predict(model, irregularity)
-
-        self.irregularities.to_csv(os.path.join(self.data_path, 'irregularities.xz'),
-                                   compression='xz',
-                                   encoding='utf-8',
-                                   index=False)
-
-    def load_trained_model(self, classifier):
-        filename = '{}.pkl'.format(classifier.__name__.lower())
-        path = os.path.join(self.data_path, filename)
-        # palliative since this model is outputting
-        # a model too large to be loaded with joblib
-        if filename == 'monthlysubquotalimitclassifier.pkl':
-            model = classifier()
-            model.fit(self.dataset)
-        else:
-            if os.path.isfile(path):
-                model = joblib.load(path)
-            else:
-                model = classifier()
-                model.fit(self.dataset)
-                joblib.dump(model, path)
-        return model
-
-    def predict(self, model, irregularity):
-        model.transform(self.dataset)
-        y = model.predict(self.dataset)
-        self.irregularities[irregularity] = y
-        if y.dtype == np.int:
-            self.irregularities.loc[y == 1, irregularity] = False
-            self.irregularities.loc[y == -1, irregularity] = True
+from rosie.chamber_of_deputies import settings
+from rosie.chamber_of_deputies.adapter import Adapter
+from rosie.core import Core
 
 
 def main(target_directory='/tmp/serenata-data'):
-    dataset = Dataset(target_directory).get()
-    ChamberOfDeputies(dataset, target_directory).run_classifiers()
+    adapter = Adapter(target_directory)
+    core = Core(settings, adapter)
+    core()

--- a/rosie/chamber_of_deputies/adapter.py
+++ b/rosie/chamber_of_deputies/adapter.py
@@ -6,13 +6,14 @@ from serenata_toolbox.ceap_dataset import CEAPDataset
 from serenata_toolbox.datasets import fetch
 
 
-class Dataset:
+class Adapter:
     COMPANIES_DATASET = '2016-09-03-companies.xz'
 
     def __init__(self, path):
         self.path = path
 
-    def get(self):
+    @property
+    def dataset(self):
         self.update_datasets()
         reimbursements = self.get_reimbursements()
         companies = self.get_companies()

--- a/rosie/chamber_of_deputies/settings.py
+++ b/rosie/chamber_of_deputies/settings.py
@@ -1,0 +1,20 @@
+from rosie.chamber_of_deputies.classifiers.election_expenses_classifier import ElectionExpensesClassifier
+from rosie.chamber_of_deputies.classifiers.meal_price_outlier_classifier import MealPriceOutlierClassifier
+from rosie.chamber_of_deputies.classifiers.monthly_subquota_limit_classifier import MonthlySubquotaLimitClassifier
+from rosie.chamber_of_deputies.classifiers.traveled_speeds_classifier import TraveledSpeedsClassifier
+from rosie.chamber_of_deputies.classifiers.irregular_companies_classifier import IrregularCompaniesClassifier
+from rosie.core.classifiers.invalid_cnpj_cpf_classifier import InvalidCnpjCpfClassifier
+
+
+CLASSIFIERS = {
+    'meal_price_outlier': MealPriceOutlierClassifier,
+    'over_monthly_subquota_limit': MonthlySubquotaLimitClassifier,
+    'suspicious_traveled_speed_day': TraveledSpeedsClassifier,
+    'invalid_cnpj_cpf': InvalidCnpjCpfClassifier,
+    'election_expenses': ElectionExpensesClassifier,
+    'irregular_companies_classifier': IrregularCompaniesClassifier
+}
+
+DATASET_KEYS = ('applicant_id', 'year', 'document_id')
+
+VALUE = 'total_net_value'

--- a/rosie/core/__init__.py
+++ b/rosie/core/__init__.py
@@ -35,7 +35,7 @@ class Core:
             self.predict(model, name)
 
         output = os.path.join(self.data_path, 'suspicions.xz')
-        kwargs = (compression='xz', encoding='utf-8', index=False)
+        kwargs = dict(compression='xz', encoding='utf-8', index=False)
         self.suspicions.to_csv(output, **kwargs)
 
     def load_trained_model(self, classifier):


### PR DESCRIPTION
This PR is complimentary to #37:

* It exemplifies how can `settings` and `adapter` modules can be helpful to make a `Core` generic pipeline
* It starts to handle what was called irregularities as _suspicions_ for semantic sake

`settings` and `adapter` module are just barely organized. Some ideas of improvements:

* Every classifier could have a `name` property (so `settings.CLASSIFIERS` could be a simple list);
* Some general variables (`settings.UNIQUE_IDS` and `settings.VALUE`) should be integrated to the `adapter` — and maybe `Core` will only require the `adapter` (not `settings`);
* Maybe in the future we don't even need the `settings` module (it could be integrated in the `adapter`).

Hint: this [talk about `class` objects in Python](https://youtu.be/HTLu2DFOdTg) can be helpful.