### PR TITLE
Mocks for Adapter class

### DIFF
--- a/rosie/chamber_of_deputies/tests/test_dataset.py
+++ b/rosie/chamber_of_deputies/tests/test_dataset.py
@@ -1,25 +1,31 @@
-import os.path
+import shutil
+import os
 from tempfile import mkdtemp
 from unittest import TestCase
 from unittest.mock import patch
 from shutil import copy2
 
-from rosie.chamber_of_deputies import settings
 from rosie.chamber_of_deputies.adapter import Adapter
 
 
 class TestDataset(TestCase):
 
     def setUp(self):
-        temp_path = mkdtemp()
-        copy2('rosie/chamber_of_deputies/tests/fixtures/companies.xz',
-              os.path.join(temp_path, settings.COMPANIES_DATASET))
-        copy2('rosie/chamber_of_deputies/tests/fixtures/reimbursements.xz', temp_path)
-        self.subject = Adapter(temp_path)
+        self.temp_path = mkdtemp()
+        fixtures = os.path.join('rosie', 'chamber_of_deputies', 'tests', 'fixtures')
+        copies = (
+            ('companies.xz', Adapter.COMPANIES_DATASET),
+            ('reimbursements.xz', 'reimbursements.xz')
+        )
+        for source, target in copies:
+            copy2(os.path.join(fixtures, source), os.path.join(self.temp_path, target))
+        self.subject = Adapter(self.temp_path)
+
+    def tearDown(self):
+        shutil.rmtree(self.temp_path)
 
     @patch('rosie.chamber_of_deputies.adapter.CEAPDataset')
     @patch('rosie.chamber_of_deputies.adapter.fetch')
-    def test_get_performs_a_left_merge_between_reimbursements_and_companies(self, _ceap_dataset, _fetch):
-        dataset = self.subject.dataset()
-        self.assertEqual(5, len(dataset))
-        self.assertEqual(1, dataset['legal_entity'].isnull().sum())
+    def test_get_performs_a_left_merge_between_reimbursements_and_companies(self, fetch, ceap):
+        self.assertEqual(5, len(self.subject.dataset))
+        self.assertEqual(1, self.subject.dataset['legal_entity'].isnull().sum())

--- a/rosie/core/__init__.py
+++ b/rosie/core/__init__.py
@@ -61,7 +61,7 @@ class Core:
     def predict(self, model, name):
         model.transform(self.dataset)
         prediction = model.predict(self.dataset)
-        self.suspicions[suspicion] = prediciton
-        if prediciton.dtype == np.int:
-            self.suspitions.loc[prediciton == 1, name] = False
-            self.suspitions.loc[prediciton == -1, name] = True
+        self.suspicions[name] = prediction
+        if prediction.dtype == np.int:
+            self.suspicions.loc[prediction == 1, name] = False
+            self.suspicions.loc[prediction == -1, name] = True


### PR DESCRIPTION
This PR fixes some broken tests by mocking the method from `rosie.chamber_of_deputies.adapter.Adapter` that downloads stuff from the original source. 

For those who are new to `unittest.mock`:

* A [live coding I made about `unittest.mock`](https://youtu.be/oITM2W6h-gg) (in pt-BR)
* [`PropertyMock`](https://docs.python.org/3/library/unittest.mock.html#unittest.mock.PropertyMock) (first time I used it)