### PR TITLE
Removing `convert_to_csv`

### DIFF
--- a/rosie/chamber_of_deputies/adapter.py
+++ b/rosie/chamber_of_deputies/adapter.py
@@ -58,7 +58,6 @@ class Adapter:
         os.makedirs(self.path, exist_ok=True)
         chamber_of_deputies = Dataset(self.path)
         chamber_of_deputies.fetch()
-        chamber_of_deputies.convert_to_csv()
         chamber_of_deputies.translate()
         chamber_of_deputies.clean()
         fetch(self.COMPANIES_DATASET, self.path)


### PR DESCRIPTION
`convert_to_csv` was deprecated in a major PR made by @luizcavalcanti (thanks ❤). This PR intends to remove it from Rosie's code so we can accept [this PR](https://github.com/datasciencebr/serenata-toolbox/pull/123)