### PR TITLE
Generate a smaller docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,4 @@
-FROM python:3.5.4-jessie
-
-USER root
-
-RUN apt-get update && apt-get install apt-transport-https -y
-
-RUN apt-get install -y \
-  build-essential \
-  libxml2-dev \
-  libxslt1-dev \
-  python3-dev \
-  unzip \
-  zlib1g-dev
-  
-RUN pip install --upgrade pip
+FROM python:3.6-slim
 
 COPY requirements.txt ./
 COPY setup ./
@@ -20,6 +6,25 @@ COPY rosie.py ./
 COPY rosie ./rosie
 COPY config.ini.example ./
 
-RUN ./setup
+RUN apt-get update \ 
+  && apt-get install apt-transport-https -y --no-install-recommends \
+        build-essential \
+        libxml2-dev \
+        libxslt1-dev \
+        python3 \
+        python3-dev \
+        unzip \
+        zlib1g-dev \
+  && pip install --upgrade pip \
+  && ./setup \
+  && apt-get purge -y --auto-remove apt-transport-https \
+        build-essential \
+        libxml2-dev \
+        libxslt1-dev \
+        python3-dev \
+        zlib1g-dev \
+  && rm -r /var/lib/apt/lists/* \
+  && rm -Rf /root/.cache/pip
 
-CMD python rosie.py run
+
+ENTRYPOINT ["python", "rosie.py"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,6 @@ RUN apt-get update \
         build-essential \
         libxml2-dev \
         libxslt1-dev \
-        python3 \
         python3-dev \
         unzip \
         zlib1g-dev \

--- a/README.md
+++ b/README.md
@@ -13,11 +13,17 @@ A Python application reading receipts from the [Quota for Exercising Parliamenta
 
 ```console
 $ docker build -t rosie .
-$ docker run --rm -v /tmp/serenata-data:/tmp/serenata-data rosie
-
+$ docker run --rm -v /tmp/serenata-data:/tmp/serenata-data rosie run <module_name>
 ```
 
 Then check your `/tmp/serenata-data/` directory in you host machine for `irregularities.xz`.
+
+For testing
+
+```console
+$ docker build -t rosie .
+$ docker run --rm -v /tmp/serenata-data:/tmp/serenata-data rosie test
+```
 
 ### Without Docker
 


### PR DESCRIPTION
This is just a template to help you make your point clear with this PR. :)


**What is the purpose of this Pull Request?**
Generate a smaller docker image. From 1.38GB to 707 M
Change from CMD to Entrypoint. The command should be 
docker run --rm -v /tmp/serenata-data:/tmp/serenata-data rosie <module_name>

**What was done to achieve this purpose?**
Lesser layers and purging not needed packages

**How to test if it really works?**
docker build . -t rosie
docker run --rm -v /tmp/serenata-data:/tmp/serenata-data rosie test

**Who can help reviewing it?**
Anyone with docker :)

**TODO**
I tried using alpine image but the libs need for scikit-learn and scipy are not readily available in apline (FFTW, SLIB for example) 
