### PR TITLE
Simplified the CPF testing suite

### DIFF
--- a/rosie/core/tests/test_invalid_cnpj_cpf_classifier.py
+++ b/rosie/core/tests/test_invalid_cnpj_cpf_classifier.py
@@ -7,38 +7,21 @@ from rosie.core.classifiers import InvalidCnpjCpfClassifier
 
 
 class TestInvalidCnpjCpfClassifier(TestCase):
-
     def setUp(self):
         self.dataset = pd.read_csv('rosie/core/tests/fixtures/invalid_cnpj_cpf_classifier.csv',
                                    dtype={'recipient_id': np.str})
         self.subject = InvalidCnpjCpfClassifier()
 
-    def test_is_valid_cnpj(self):
-        self.assertEqual(self.subject.predict(self.dataset)[0], False)
-
-    def test_is_invalid_cnpj(self):
-        self.assertEqual(self.subject.predict(self.dataset)[1], True)
-
-    def test_is_none(self):
-        self.assertEqual(self.subject.predict(self.dataset)[2], True)
-
-    def test_none_cnpj_cpf_abroad_is_valid(self):
-        self.assertEqual(self.subject.predict(self.dataset)[3], False)
-
-    def test_valid_cnpj_cpf_abroad_is_valid(self):
-        self.assertEqual(self.subject.predict(self.dataset)[4], False)
-
-    def test_invalid_cnpj_cpf_abroad_is_valid(self):
-        self.assertEqual(self.subject.predict(self.dataset)[5], False)
-
-    def test_is_valid_cpf(self):
-        self.assertEqual(self.subject.predict(self.dataset)[6], False)
-
-    def test_is_invalid_cpf(self):
-        self.assertEqual(self.subject.predict(self.dataset)[7], True)
-
-    def test_invalid_document_type(self):
-        self.assertEqual(self.subject.predict(self.dataset)[8], False)
+    def test_validation(self):
+        self.assertFalse(self.subject.predict(self.dataset)[0], 'Test Valid CNPJ')
+        self.assertTrue(self.subject.predict(self.dataset)[1], 'Test Invalid CNPJ')
+        self.assertTrue(self.subject.predict(self.dataset)[2], 'Test None')
+        self.assertFalse(self.subject.predict(self.dataset)[3], 'test_none_cnpj_cpf_abroad_is_valid')
+        self.assertFalse(self.subject.predict(self.dataset)[4], 'test_valid_cnpj_cpf_abroad_is_valid')
+        self.assertFalse(self.subject.predict(self.dataset)[5], 'test_invalid_cnpj_cpf_abroad_is_valid')
+        self.assertFalse(self.subject.predict(self.dataset)[6], 'Test Valid CPF')
+        self.assertTrue(self.subject.predict(self.dataset)[7], 'Test Invalid CPF')
+        self.assertFalse(self.subject.predict(self.dataset)[8], 'Test Invalid Document Type')
 
     def test_fit(self):
         self.assertEqual(self.subject.fit(self.dataset), self.subject)


### PR DESCRIPTION
CPF tests are rather verbose and hard to get around. Their structure seemed to use the test's title as a message descriptor rather than the message argument in the assertion call. Tests now are closed um on a per-feature basis, make proper use of the specialised assertions in the `unittest` module, and use the message field for descriptions.

@lipemorais Does this more or less share your view on how the tests should be refactored?