### PR TITLE
Ask pyup.io to ignore the toolbox

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,4 @@ numpy==1.13.3
 scipy==1.0.0
 pycpfcnpj==1.3
 scikit-learn==0.19.1
-serenata-toolbox==12.2.2
+serenata-toolbox # pyup: ignore


### PR DESCRIPTION
**What is the purpose of this Pull Request?**

#103 actually fixed the version of `serenata-toolbox`, so we'd need to wait for a PR (even an automatic PR from pyup.io) to guarantee we are working with the newest version of this package — this is not cool.

**What was done to achieve this purpose?**

I asked pyup.io to ignore the package so every time we `pip install` it we get the most recent update.

**How to test if it really works?**

My suggestion:

1. `pip install` a really old version of the toolbox
2. `pip install -r requirements.txt` and check if the toolbox was updated

**Who can help reviewing it?**
@anaschwendler 
